### PR TITLE
Add resources for KubeInvaders demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Festive-Tech-Calendar-2022
 This repository contains materials and resources presented as part of the **"Can we prevent the Grinch from stealing Christmas with chaos engineering?"** session.
 
+* **aks-kubeinvaders-demo:** resources that were used during demo of chaos engineering with KubeInvaders tool.
+* **learning-resources.md:** additional material like videos, blog posts and documentation that can help you learn more about chaos engineering.
+
 ![ftc22-banner](https://user-images.githubusercontent.com/47773700/200032439-c417080d-8db1-4625-a9e4-ecbc2e258c1b.png)

--- a/aks-kubeinvaders-demo/README.md
+++ b/aks-kubeinvaders-demo/README.md
@@ -1,2 +1,7 @@
 This folder contains resources for the demo of chaos engineering experiments with KubeInvaders tool.
-In the terraform folder you can find infrastructure provisioning templates that will set up a simple AKS cluster that you can install applications to straight away.
+
+In the ```terraform``` folder you can find infrastructure provisioning templates that will set up a simple AKS cluster that you can install applications to straight away.
+
+In the ```app-deploy-templates``` folder you can find Kubernetes YAML templates to deploy demo app, Nyan Cat, and KubeInvaders (values file for deploying it with Helm chart is provided) to the provisioned AKS cluster.
+
+```deploy-demo.sh``` contains detailed instructions and commands that you would need to set it all up.

--- a/aks-kubeinvaders-demo/README.md
+++ b/aks-kubeinvaders-demo/README.md
@@ -1,0 +1,2 @@
+This folder contains resources for the demo of chaos engineering experiments with KubeInvaders tool.
+In the terraform folder you can find infrastructure provisioning templates that will set up a simple AKS cluster that you can install applications to straight away.

--- a/aks-kubeinvaders-demo/app-deploy-templates/chaos-nyan-cat-deploy.yaml
+++ b/aks-kubeinvaders-demo/app-deploy-templates/chaos-nyan-cat-deploy.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: chaos-nyan-cat
+  namespace: chaos-nyan-cat
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: chaos-nyan-cat
+  template:
+    metadata:
+      labels:
+        app: chaos-nyan-cat
+    spec:
+      containers:
+      - name: chaos-nyan-cat
+        image: guidemetothemoon/kube-nyan-cat:latest
+        ports:
+        - name: http
+          containerPort: 80
+          protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: chaos-nyan-cat
+  namespace: chaos-nyan-cat
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: http
+    protocol: TCP
+    name: http
+  selector:
+    app: chaos-nyan-cat

--- a/aks-kubeinvaders-demo/app-deploy-templates/chaos-nyan-cat-ingress.yaml
+++ b/aks-kubeinvaders-demo/app-deploy-templates/chaos-nyan-cat-ingress.yaml
@@ -9,7 +9,7 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /
 spec:
   rules:
-  - host: chaos-nyan-cat.0052554060204bd09309.northeurope.aksapp.io #[AKS_DNS_ZONE]
+  - host: chaos-nyan-cat.[AKS_DNS_ZONE]
     http:
       paths:
       - backend:

--- a/aks-kubeinvaders-demo/app-deploy-templates/chaos-nyan-cat-ingress.yaml
+++ b/aks-kubeinvaders-demo/app-deploy-templates/chaos-nyan-cat-ingress.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: chaos-nyan-cat-ingress
+  namespace: chaos-nyan-cat
+  annotations:
+    #kubernetes.io/ingress.class: nginx
+    kubernetes.io/ingress.class: addon-http-application-routing
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - host: chaos-nyan-cat.0052554060204bd09309.northeurope.aksapp.io #[AKS_DNS_ZONE]
+    http:
+      paths:
+      - backend:
+          service:
+            name: chaos-nyan-cat
+            port:
+              number: 80
+        path: /
+        pathType: Prefix

--- a/aks-kubeinvaders-demo/app-deploy-templates/kubeinvaders-values.yaml
+++ b/aks-kubeinvaders-demo/app-deploy-templates/kubeinvaders-values.yaml
@@ -60,7 +60,7 @@ ingress:
     kubernetes.io/ingress.class: addon-http-application-routing
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
-  hostName: "kubeinvaders.0052554060204bd09309.northeurope.aksapp.io" #[AKS_DNS_ZONE]
+  hostName: "kubeinvaders.[AKS_DNS_ZONE]"
   tls: {}
 
 # Use route_host only if ingress is disabled

--- a/aks-kubeinvaders-demo/app-deploy-templates/kubeinvaders-values.yaml
+++ b/aks-kubeinvaders-demo/app-deploy-templates/kubeinvaders-values.yaml
@@ -1,0 +1,70 @@
+# Default values for kubeinvaders.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+nameOverride: ""
+fullnameOverride: ""
+
+config:
+  # target_namespace where kubeinvaders should be allowed to kill pods
+  target_namespace: "chaos-nyan-cat"
+  alienProximity: 10
+  hitsLimit: 1
+  updateTime: 0.5
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: kubeinvaders
+
+clusterRole:
+  create: true
+  # The name of a cluster role to bind to; if not set and create is
+  # true, a name based on fullname is generated
+  name: kubeinvaders
+
+deployment:
+  replicaCount: 1
+  image:
+    repository: luckysideburn/kubeinvaders
+    tag: v1.9
+    pullPolicy: Always
+  extraEnv: []
+  # - name: FOO
+  #   value: "BAR"
+  extraVolumes: []
+  # - name: tmp
+  #   emptyDir: {}
+  extraVolumeMounts: []
+  # - name: tmp
+  #   mountPath: /usr/local/openresty
+  resources: {}
+  nodeSelector: {}
+  tolerations: []
+  securityContext: {}
+
+service:
+  type: ClusterIP
+  port: 8080
+
+ingress:
+  enabled: true
+  legacyIngress: false
+  annotations:
+    kubernetes.io/ingress.class: addon-http-application-routing
+    nginx.ingress.kubernetes.io/rewrite-target: /
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+  hostName: "kubeinvaders.0052554060204bd09309.northeurope.aksapp.io" #[AKS_DNS_ZONE]
+  tls: {}
+
+# Use route_host only if ingress is disabled
+route_host: ""
+
+serviceMonitor:
+  enabled: false

--- a/aks-kubeinvaders-demo/deploy-demo.sh
+++ b/aks-kubeinvaders-demo/deploy-demo.sh
@@ -1,0 +1,6 @@
+cd app-deployment-templates
+helm repo add kubeinvaders https://lucky-sideburn.github.io/helm-charts/
+
+kubectl create namespace kubeinvaders chaos-nyan-cat
+helm install kubeinvaders --set-string target_namespace="chaos-nyan-cat" -n kubeinvaders kubeinvaders/kubeinvaders -f kubeinvaders-values.yaml --set image.tag=v1.9 --version 1.9
+kubectl apply -f chaos-nyan-cat-deploy.yaml -f chaos-nyan-cat-ingress.yaml -n chaos-nyan-cat

--- a/aks-kubeinvaders-demo/deploy-demo.sh
+++ b/aks-kubeinvaders-demo/deploy-demo.sh
@@ -1,6 +1,38 @@
+# Based upon this link from Microsoft - it has all the information you need to set up Terraform with Azure: https://learn.microsoft.com/en-us/azure/developer/terraform/create-k8s-cluster-with-tf-and-aks
+
+# 1. Create service principal to be able to provision infrastructure in Azure from Terraform
+az ad sp create-for-rbac --name <service_principal_name> --role Contributor --scopes /subscriptions/<azure_subscription_id>
+
+# 2. Replace placeholders in terraform.tfvars with recently created service principal appid and password
+
+# 3. Create an AKS cluster with Terraform
+# A basic AKS cluster will be created with 1 Linux node, Log Analytics and HTTP Application Routing add-on
+
+terraform init
+terraform plan -out main.tfplan
+terraform apply main.tfplan
+
+
+# 4. Install applications on Anewly created KS cluster - demo app (NYAN CAT) and KubeInvaders for chaos experiments
+
+# 4.1.0 Get DNS Zone that was created by HTTP Application Routing add-on for AKS cluster
+az aks addon show --addon http_application_routing --name aks-kubeinvaders --resource-group aks-kubeinvaders-rg | grep HTTPApplicationRoutingZoneName
+
+# 4.1.1 Replace [AKS_DNS_ZONE] placeholder in app-deploy-templates/chaos-nyan-cat-ingress.yaml and app-deploy-templates/kubeinvaders-values.yaml with value retrieved from 4.1.0
+
+# 4.1.2 Deploy applications to AKS
 cd app-deployment-templates
 helm repo add kubeinvaders https://lucky-sideburn.github.io/helm-charts/
 
-kubectl create namespace kubeinvaders chaos-nyan-cat
-helm install kubeinvaders --set-string target_namespace="chaos-nyan-cat" -n kubeinvaders kubeinvaders/kubeinvaders -f kubeinvaders-values.yaml --set image.tag=v1.9 --version 1.9
+kubectl create namespace kubeinvaders && kubectl create namespace chaos-nyan-cat
+helm upgrade --install kubeinvaders --set-string target_namespace="chaos-nyan-cat" -n kubeinvaders kubeinvaders/kubeinvaders -f kubeinvaders-values.yaml --set image.tag=v1.9 --version 1.9
 kubectl apply -f chaos-nyan-cat-deploy.yaml -f chaos-nyan-cat-ingress.yaml -n chaos-nyan-cat
+
+# 5. Clean up all resources (including service principal)
+
+terraform plan -destroy -out main.destroy.tfplan
+terraform apply main.destroy.tfplan
+
+az ad sp show --id <service_principal_app_id>
+az ad sp list --display-name "<service_principal_display_name>" --query "[].{\"Object ID\":id}" --output table
+az ad sp delete --id <service_principal_object_id>

--- a/aks-kubeinvaders-demo/terraform/main.tf
+++ b/aks-kubeinvaders-demo/terraform/main.tf
@@ -1,0 +1,66 @@
+# Generate random resource group name
+resource "random_pet" "rg_name" {
+  prefix = var.resource_group_name_prefix
+}
+
+resource "azurerm_resource_group" "rg" {
+  location = var.resource_group_location
+  name     = random_pet.rg_name.id
+}
+
+resource "random_id" "log_analytics_workspace_name_suffix" {
+  byte_length = 8
+}
+
+resource "azurerm_log_analytics_workspace" "test" {
+  location            = var.log_analytics_workspace_location
+  # The WorkSpace name has to be unique across the whole of azure;
+  # not just the current subscription/tenant.
+  name                = "${var.log_analytics_workspace_name}-${random_id.log_analytics_workspace_name_suffix.dec}"
+  resource_group_name = azurerm_resource_group.rg.name
+  sku                 = var.log_analytics_workspace_sku
+}
+
+resource "azurerm_log_analytics_solution" "test" {
+  location              = azurerm_log_analytics_workspace.test.location
+  resource_group_name   = azurerm_resource_group.rg.name
+  solution_name         = "ContainerInsights"
+  workspace_name        = azurerm_log_analytics_workspace.test.name
+  workspace_resource_id = azurerm_log_analytics_workspace.test.id
+
+  plan {
+    product   = "OMSGallery/ContainerInsights"
+    publisher = "Microsoft"
+  }
+}
+
+resource "azurerm_kubernetes_cluster" "k8s" {
+  location            = azurerm_resource_group.rg.location
+  name                = var.cluster_name
+  resource_group_name = azurerm_resource_group.rg.name
+  dns_prefix          = var.dns_prefix
+  tags                = {
+    Environment = "Development"
+  }
+
+  default_node_pool {
+    name       = "agentpool"
+    vm_size    = "Standard_D2_v2"
+    node_count = var.agent_count
+  }
+  linux_profile {
+    admin_username = "ubuntu"
+
+    ssh_key {
+      key_data = file(var.ssh_public_key)
+    }
+  }
+  network_profile {
+    network_plugin    = "kubenet"
+    load_balancer_sku = "standard"
+  }
+  service_principal {
+    client_id     = var.aks_service_principal_app_id
+    client_secret = var.aks_service_principal_client_secret
+  }
+}

--- a/aks-kubeinvaders-demo/terraform/main.tf
+++ b/aks-kubeinvaders-demo/terraform/main.tf
@@ -1,11 +1,6 @@
-# Generate random resource group name
-resource "random_pet" "rg_name" {
-  prefix = var.resource_group_name_prefix
-}
-
-resource "azurerm_resource_group" "rg" {
+resource "azurerm_resource_group" "resource_group" {
   location = var.resource_group_location
-  name     = random_pet.rg_name.id
+  name     = "${var.resource_group_name}-rg"
 }
 
 resource "random_id" "log_analytics_workspace_name_suffix" {
@@ -17,13 +12,13 @@ resource "azurerm_log_analytics_workspace" "test" {
   # The WorkSpace name has to be unique across the whole of azure;
   # not just the current subscription/tenant.
   name                = "${var.log_analytics_workspace_name}-${random_id.log_analytics_workspace_name_suffix.dec}"
-  resource_group_name = azurerm_resource_group.rg.name
+  resource_group_name = azurerm_resource_group.resource_group.name
   sku                 = var.log_analytics_workspace_sku
 }
 
 resource "azurerm_log_analytics_solution" "test" {
   location              = azurerm_log_analytics_workspace.test.location
-  resource_group_name   = azurerm_resource_group.rg.name
+  resource_group_name   = azurerm_resource_group.resource_group.name
   solution_name         = "ContainerInsights"
   workspace_name        = azurerm_log_analytics_workspace.test.name
   workspace_resource_id = azurerm_log_analytics_workspace.test.id
@@ -35,9 +30,9 @@ resource "azurerm_log_analytics_solution" "test" {
 }
 
 resource "azurerm_kubernetes_cluster" "k8s" {
-  location            = azurerm_resource_group.rg.location
+  location            = azurerm_resource_group.resource_group.location
   name                = var.cluster_name
-  resource_group_name = azurerm_resource_group.rg.name
+  resource_group_name = azurerm_resource_group.resource_group.name
   dns_prefix          = var.dns_prefix
   tags                = {
     Environment = "Development"

--- a/aks-kubeinvaders-demo/terraform/main.tf
+++ b/aks-kubeinvaders-demo/terraform/main.tf
@@ -45,7 +45,7 @@ resource "azurerm_kubernetes_cluster" "k8s" {
 
   default_node_pool {
     name       = "agentpool"
-    vm_size    = "Standard_D2_v2"
+    vm_size    = "Standard_B2s"
     node_count = var.agent_count
   }
   linux_profile {

--- a/aks-kubeinvaders-demo/terraform/main.tf
+++ b/aks-kubeinvaders-demo/terraform/main.tf
@@ -1,27 +1,42 @@
+# Create AKS resource group
 resource "azurerm_resource_group" "resource_group" {
   location = var.resource_group_location
   name     = "${var.resource_group_name}-rg"
 }
 
+# Create AKS VNet
+resource "azurerm_virtual_network" "virtual_network" {
+  name =  "${var.cluster_name}-vnet"
+  location = var.resource_group_location
+  resource_group_name = azurerm_resource_group.resource_group.name
+  address_space = [var.network_address_space]
+}
+ 
+resource "azurerm_subnet" "aks_subnet" {
+  name = var.subnet_name
+  resource_group_name  = azurerm_resource_group.resource_group.name
+  virtual_network_name = azurerm_virtual_network.virtual_network.name
+  address_prefixes = [var.subnet_address_prefix]
+}
+
+# Create Log Analytics resources
 resource "random_id" "log_analytics_workspace_name_suffix" {
   byte_length = 8
 }
 
-resource "azurerm_log_analytics_workspace" "test" {
+resource "azurerm_log_analytics_workspace" "aks_log_analytics_workspace" {
   location            = var.log_analytics_workspace_location
-  # The WorkSpace name has to be unique across the whole of azure;
-  # not just the current subscription/tenant.
   name                = "${var.log_analytics_workspace_name}-${random_id.log_analytics_workspace_name_suffix.dec}"
   resource_group_name = azurerm_resource_group.resource_group.name
   sku                 = var.log_analytics_workspace_sku
 }
 
-resource "azurerm_log_analytics_solution" "test" {
-  location              = azurerm_log_analytics_workspace.test.location
+resource "azurerm_log_analytics_solution" "aks_log_analytics_solution" {
+  location              = azurerm_log_analytics_workspace.aks_log_analytics_workspace.location
   resource_group_name   = azurerm_resource_group.resource_group.name
   solution_name         = "ContainerInsights"
-  workspace_name        = azurerm_log_analytics_workspace.test.name
-  workspace_resource_id = azurerm_log_analytics_workspace.test.id
+  workspace_name        = azurerm_log_analytics_workspace.aks_log_analytics_workspace.name
+  workspace_resource_id = azurerm_log_analytics_workspace.aks_log_analytics_workspace.id
 
   plan {
     product   = "OMSGallery/ContainerInsights"
@@ -29,31 +44,35 @@ resource "azurerm_log_analytics_solution" "test" {
   }
 }
 
-resource "azurerm_kubernetes_cluster" "k8s" {
-  location            = azurerm_resource_group.resource_group.location
-  name                = var.cluster_name
-  resource_group_name = azurerm_resource_group.resource_group.name
-  dns_prefix          = var.dns_prefix
-  tags                = {
+resource "azurerm_kubernetes_cluster" "aks" {
+  location                         = azurerm_resource_group.resource_group.location
+  name                             = var.cluster_name
+  resource_group_name              = azurerm_resource_group.resource_group.name
+  dns_prefix                       = var.dns_prefix
+  kubernetes_version               = var.kubernetes_version
+  http_application_routing_enabled = true
+  tags                             = {
     Environment = "Development"
   }
 
   default_node_pool {
-    name       = "agentpool"
-    vm_size    = "Standard_B2s"
-    node_count = var.agent_count
+    name                 = "agentpool"
+    vm_size              = "Standard_B2s"
+    node_count           = var.agent_count
+    vnet_subnet_id       = azurerm_subnet.aks_subnet.id
+    type                 = "VirtualMachineScaleSets"
+    orchestrator_version = var.kubernetes_version
   }
-  linux_profile {
-    admin_username = "ubuntu"
+  
+  oms_agent {
+      log_analytics_workspace_id = azurerm_log_analytics_workspace.aks_log_analytics_workspace.id
+  }
 
-    ssh_key {
-      key_data = file(var.ssh_public_key)
-    }
-  }
   network_profile {
-    network_plugin    = "kubenet"
+    network_plugin    = "azure"
     load_balancer_sku = "standard"
   }
+
   service_principal {
     client_id     = var.aks_service_principal_app_id
     client_secret = var.aks_service_principal_client_secret

--- a/aks-kubeinvaders-demo/terraform/outputs.tf
+++ b/aks-kubeinvaders-demo/terraform/outputs.tf
@@ -1,0 +1,38 @@
+output "client_certificate" {
+  value     = azurerm_kubernetes_cluster.k8s.kube_config[0].client_certificate
+  sensitive = true
+}
+
+output "client_key" {
+  value     = azurerm_kubernetes_cluster.k8s.kube_config[0].client_key
+  sensitive = true
+}
+
+output "cluster_ca_certificate" {
+  value     = azurerm_kubernetes_cluster.k8s.kube_config[0].cluster_ca_certificate
+  sensitive = true
+}
+
+output "cluster_password" {
+  value     = azurerm_kubernetes_cluster.k8s.kube_config[0].password
+  sensitive = true
+}
+
+output "cluster_username" {
+  value     = azurerm_kubernetes_cluster.k8s.kube_config[0].username
+  sensitive = true
+}
+
+output "host" {
+  value     = azurerm_kubernetes_cluster.k8s.kube_config[0].host
+  sensitive = true
+}
+
+output "kube_config" {
+  value     = azurerm_kubernetes_cluster.k8s.kube_config_raw
+  sensitive = true
+}
+
+output "resource_group_name" {
+  value = azurerm_resource_group.rg.name
+}

--- a/aks-kubeinvaders-demo/terraform/outputs.tf
+++ b/aks-kubeinvaders-demo/terraform/outputs.tf
@@ -1,35 +1,35 @@
 output "client_certificate" {
-  value     = azurerm_kubernetes_cluster.k8s.kube_config[0].client_certificate
+  value     = azurerm_kubernetes_cluster.aks.kube_config[0].client_certificate
   sensitive = true
 }
 
 output "client_key" {
-  value     = azurerm_kubernetes_cluster.k8s.kube_config[0].client_key
+  value     = azurerm_kubernetes_cluster.aks.kube_config[0].client_key
   sensitive = true
 }
 
 output "cluster_ca_certificate" {
-  value     = azurerm_kubernetes_cluster.k8s.kube_config[0].cluster_ca_certificate
+  value     = azurerm_kubernetes_cluster.aks.kube_config[0].cluster_ca_certificate
   sensitive = true
 }
 
 output "cluster_password" {
-  value     = azurerm_kubernetes_cluster.k8s.kube_config[0].password
+  value     = azurerm_kubernetes_cluster.aks.kube_config[0].password
   sensitive = true
 }
 
 output "cluster_username" {
-  value     = azurerm_kubernetes_cluster.k8s.kube_config[0].username
+  value     = azurerm_kubernetes_cluster.aks.kube_config[0].username
   sensitive = true
 }
 
 output "host" {
-  value     = azurerm_kubernetes_cluster.k8s.kube_config[0].host
+  value     = azurerm_kubernetes_cluster.aks.kube_config[0].host
   sensitive = true
 }
 
 output "kube_config" {
-  value     = azurerm_kubernetes_cluster.k8s.kube_config_raw
+  value     = azurerm_kubernetes_cluster.aks.kube_config_raw
   sensitive = true
 }
 

--- a/aks-kubeinvaders-demo/terraform/outputs.tf
+++ b/aks-kubeinvaders-demo/terraform/outputs.tf
@@ -34,5 +34,5 @@ output "kube_config" {
 }
 
 output "resource_group_name" {
-  value = azurerm_resource_group.rg.name
+  value = azurerm_resource_group.resource_group.name
 }

--- a/aks-kubeinvaders-demo/terraform/providers.tf
+++ b/aks-kubeinvaders-demo/terraform/providers.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">=1.1.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~>3.0.2"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~>3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/aks-kubeinvaders-demo/terraform/terraform.tfvars
+++ b/aks-kubeinvaders-demo/terraform/terraform.tfvars
@@ -1,0 +1,2 @@
+aks_service_principal_app_id = "<service_principal_app_id>"
+aks_service_principal_client_secret = "<service_principal_password>"

--- a/aks-kubeinvaders-demo/terraform/terraform.tfvars
+++ b/aks-kubeinvaders-demo/terraform/terraform.tfvars
@@ -1,2 +1,2 @@
-aks_service_principal_app_id = "<service_principal_app_id>"
+aks_service_principal_app_id =  "<service_principal_app_id>"
 aks_service_principal_client_secret = "<service_principal_password>"

--- a/aks-kubeinvaders-demo/terraform/variables.tf
+++ b/aks-kubeinvaders-demo/terraform/variables.tf
@@ -32,14 +32,14 @@ variable "log_analytics_workspace_sku" {
   default = "PerGB2018"
 }
 
+variable "resource_group_name" {
+  default     = "aks-kubeinvaders"
+  description = "Name of the resource group."
+}
+
 variable "resource_group_location" {
   default     = "northeurope"
   description = "Location of the resource group."
-}
-
-variable "resource_group_name_prefix" {
-  default     = "rg"
-  description = "Prefix of the resource group name that's combined with a random ID so name is unique in your Azure subscription."
 }
 
 variable "ssh_public_key" {

--- a/aks-kubeinvaders-demo/terraform/variables.tf
+++ b/aks-kubeinvaders-demo/terraform/variables.tf
@@ -1,0 +1,49 @@
+variable "agent_count" {
+  default = 3
+}
+
+# The following two variable declarations are placeholder references.
+# Set the values for these variable in terraform.tfvars
+variable "aks_service_principal_app_id" {
+  default = ""
+}
+
+variable "aks_service_principal_client_secret" {
+  default = ""
+}
+
+variable "cluster_name" {
+  default = "aks-kubeinvaders"
+}
+
+variable "dns_prefix" {
+  default = "aks-kubeinvaders"
+}
+
+# Refer to https://azure.microsoft.com/global-infrastructure/services/?products=monitor for available Log Analytics regions.
+variable "log_analytics_workspace_location" {
+  default = "northeurope"
+}
+
+variable "log_analytics_workspace_name" {
+  default = "aksLogAnalyticsWorkspace"
+}
+
+# Refer to https://azure.microsoft.com/pricing/details/monitor/ for Log Analytics pricing
+variable "log_analytics_workspace_sku" {
+  default = "PerGB2018"
+}
+
+variable "resource_group_location" {
+  default     = "northeurope"
+  description = "Location of the resource group."
+}
+
+variable "resource_group_name_prefix" {
+  default     = "rg"
+  description = "Prefix of the resource group name that's combined with a random ID so name is unique in your Azure subscription."
+}
+
+variable "ssh_public_key" {
+  default = "~/.ssh/id_rsa.pub"
+}

--- a/aks-kubeinvaders-demo/terraform/variables.tf
+++ b/aks-kubeinvaders-demo/terraform/variables.tf
@@ -1,47 +1,85 @@
-variable "agent_count" {
-  default = 1
-}
-
 # The following two variable declarations are placeholder references.
 # Set the values for these variable in terraform.tfvars
 variable "aks_service_principal_app_id" {
-  default = ""
+  type        = string
+  default     = ""
+  description = "Service Principal application ID"
 }
 
 variable "aks_service_principal_client_secret" {
-  default = ""
-}
-
-variable "cluster_name" {
-  default = "aks-kubeinvaders"
-}
-
-variable "dns_prefix" {
-  default = "akskubeinvaders"
-}
-
-variable "log_analytics_workspace_location" {
-  default = "northeurope"
-}
-
-variable "log_analytics_workspace_name" {
-  default = "aksLogAnalyticsWorkspace"
-}
-
-variable "log_analytics_workspace_sku" {
-  default = "PerGB2018"
+  type        = string
+  default     = ""
+  description = "Service Principal client secret"
 }
 
 variable "resource_group_name" {
+  type        = string
   default     = "aks-kubeinvaders"
   description = "Name of the resource group."
 }
 
 variable "resource_group_location" {
-  default     = "northeurope"
+  type        = string
+  default     = "westeurope"
   description = "Location of the resource group."
 }
 
-variable "ssh_public_key" {
-  default = "~/.ssh/id_rsa.pub"
+variable "cluster_name" {
+  type        = string  
+  default     = "aks-kubeinvaders"
+  description = "AKS cluster name"
+}
+
+variable "dns_prefix" {
+  type        = string
+  default     = "akskubeinvaders"
+  description = "AKS DNS zone prefix"
+}
+
+variable "network_address_space" {
+  type        = string
+  default     = "172.16.0.0/16"
+  description = "AKS VNet address space"
+}
+ 
+variable "subnet_name" {
+  type        = string
+  default     = "default"
+  description = "AKS subnet name"
+}
+ 
+variable "subnet_address_prefix" {
+  type        = string
+  default     = "172.16.0.0/24"
+  description = "AKS subnet address space"
+}
+
+variable "agent_count" {
+  type        = number
+  default     = 1
+  description = "Count of VMs to deploy in AKS node pool"
+}
+
+variable "log_analytics_workspace_location" {
+  type        = string
+  default     = "westeurope"
+  description = "Location of Log Analytics Workspace"
+}
+
+variable "log_analytics_workspace_name" {
+  type        = string
+  default     = "aksLogAnalyticsWorkspace"
+  description = "Log Analytics Workspace name"
+}
+
+variable "log_analytics_workspace_sku" {
+  type        = string
+  default     = "PerGB2018"
+  description = "SKU that Log Analytics Workspace will use"
+}
+ 
+variable "kubernetes_version" {
+  type        = string
+  default     = "1.23.12"
+  description = "AKS cluster Kubernetes version"
 }

--- a/aks-kubeinvaders-demo/terraform/variables.tf
+++ b/aks-kubeinvaders-demo/terraform/variables.tf
@@ -1,5 +1,5 @@
 variable "agent_count" {
-  default = 3
+  default = 1
 }
 
 # The following two variable declarations are placeholder references.
@@ -17,10 +17,9 @@ variable "cluster_name" {
 }
 
 variable "dns_prefix" {
-  default = "aks-kubeinvaders"
+  default = "akskubeinvaders"
 }
 
-# Refer to https://azure.microsoft.com/global-infrastructure/services/?products=monitor for available Log Analytics regions.
 variable "log_analytics_workspace_location" {
   default = "northeurope"
 }
@@ -29,7 +28,6 @@ variable "log_analytics_workspace_name" {
   default = "aksLogAnalyticsWorkspace"
 }
 
-# Refer to https://azure.microsoft.com/pricing/details/monitor/ for Log Analytics pricing
 variable "log_analytics_workspace_sku" {
   default = "PerGB2018"
 }


### PR DESCRIPTION
Added a separate folder that will include resources to set up all the resources that were shown as part of KubeInvaders demo:

- Terraform templates to provision basic AKS cluster with a single Linux node, Log Analytics and HTTP Application Routing add-on;
- Kubernetes YAML templates to provision demo app (Nyan Cat) and KubeInvaders Helm chart (values.yaml is provided) to the respective AKS cluster;
- Deployment script that contains all the instructions and commands in proper order that are needed to set it all up from scratch;
- README file that contains overall information about the folder and included resources;